### PR TITLE
README example: avoid WebSockex.BadResponseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ defmodule WebSocketExample do
   end
 
   def handle_frame({type, msg}, state) do
-    IO.puts "Recieved Message - Type: #{inspect type} -- Message: #{inspect msg}"
+    IO.puts "Received Message - Type: #{inspect type} -- Message: #{inspect msg}"
+    {:ok, state}
   end
 end
 ```


### PR DESCRIPTION
In `handle_frame`, return `{:ok, state}` instead of `:ok` (from `IO.puts`) to avoid:

```
** (EXIT from #PID<0.104.0>) an exception was raised:
    ** (WebSockex.BadResponseError) Bad Response: Got :ok from "XYZ.handle_frame({:text, \"{\\\"id\\\":443585,\\\"result\\\":{}}\"}, :state)"
        (websockex) lib/websockex/client.ex:390: WebSockex.Client.common_handle/4
        (websockex) lib/websockex/client.ex:252: WebSockex.Client.init/5
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```