### PR TITLE
Add handle_connect_failure callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 - `WebSockex.start_link` will no longer cause the calling process to exit on
   connection failure and will return a proper error tuple instead.
+- Change `WebSockex.Conn.RequestError` to `WebSockex.RequestError`.
 
 ## 0.1.2
 - Rework how disconnects are handled which should improve the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - `WebSockex.start_link` will no longer cause the calling process to exit on
   connection failure and will return a proper error tuple instead.
 - Change `WebSockex.Conn.RequestError` to `WebSockex.RequestError`.
+- Add `handle_connect_failure` to be invoked after initiating a connection
+  fails. Fixes #5
 
 ## 0.1.2
 - Rework how disconnects are handled which should improve the

--- a/lib/websockex/client.ex
+++ b/lib/websockex/client.ex
@@ -53,6 +53,16 @@ defmodule WebSockex.Client do
                         | {:remote, :closed}
                         | {:error, term}
 
+  @typedoc """
+  A map that contains information about the failure to connect.
+
+  This map contains the error, attempt number, and the `t:WebSockex.Conn.t/0`
+  that was used to attempt the connection.
+  """
+  @type connect_failure_map :: %{error: %WebSockex.RequestError{} | %WebSockex.ConnError{},
+                                 attempt_number: integer,
+                                 conn: WebSockex.Conn.t}
+
   @doc """
   Invoked after connection is established.
   """
@@ -120,6 +130,24 @@ defmodule WebSockex.Client do
     | {:close, close_frame, new_state} when new_state: term
 
   @doc """
+  Invoked when there is a failure trying to open the websocket.
+
+  The failure map is the `t:connect_failure_map.t/0` type, and contains the
+  error attempt number and `t:WebSockex.Conn.t/0` used to connect. You can
+  modify the `Conn` struct to change various things about the way you're
+  attmpting to connect.
+
+  - `{:ok, state}` will continue the process termination or error.
+  - `{:reconnect, state}` will attempt to reconnect instead of terminating.
+  - `{:reconnect, conn, state}` will attempt to reconnect with the connection
+    data in `conn`. `conn` is expected to be a `t:WebSockex.Conn.t/0`.
+  """
+  @callback handle_connect_failure(connect_failure_map, state :: term) ::
+    {:ok, new_state}
+    | {:reconnect, new_state}
+    | {:reconnect, WebSockex.Conn.t, new_state} when new_state: term
+
+  @doc """
   Invoked when the process is terminating.
   """
   @callback terminate(close_reason, state :: term) :: any
@@ -132,8 +160,8 @@ defmodule WebSockex.Client do
     {:ok, new_state :: term}
     | {:error, reason :: term}
 
-  @optional_callbacks [handle_disconnect: 2, handle_ping: 2, handle_pong: 2, terminate: 2,
-                       code_change: 3]
+  @optional_callbacks [handle_disconnect: 2, handle_ping: 2, handle_pong: 2, handle_connect_failure: 2,
+                       terminate: 2, code_change: 3]
 
   defmacro __using__(_) do
     quote location: :keep do
@@ -179,13 +207,17 @@ defmodule WebSockex.Client do
       def handle_pong({:pong, _}, state), do: {:ok, state}
 
       @doc false
+      def handle_connect_failure(_failure_map, state), do: {:ok, state}
+
+      @doc false
       def terminate(_close_reason, _state), do: :ok
 
       @doc false
       def code_change(_old_vsn, state, _extra), do: {:ok, state}
 
       defoverridable [init: 2, handle_frame: 2, handle_cast: 2, handle_info: 2, handle_ping: 2,
-                      handle_pong: 2, handle_disconnect: 2, terminate: 2, code_change: 3]
+                      handle_pong: 2, handle_disconnect: 2, handle_connect_failure: 2,
+                      terminate: 2, code_change: 3]
     end
   end
 

--- a/lib/websockex/conn.ex
+++ b/lib/websockex/conn.ex
@@ -193,7 +193,7 @@ defmodule WebSockex.Conn do
       {:ok, {:http_response, _version, 101, _message}, rest} ->
          decode_headers(rest)
       {:ok, {:http_response, _, code, message}, _} ->
-        {:error, %WebSockex.Conn.RequestError{code: code, message: message}}
+        {:error, %WebSockex.RequestError{code: code, message: message}}
       {:error, error} ->
         {:error, error}
     end

--- a/lib/websockex/errors.ex
+++ b/lib/websockex/errors.ex
@@ -6,7 +6,7 @@ defmodule WebSockex.ConnError do
   def message(%__MODULE__{original: error}), do: "Connection Error: #{inspect error}"
 end
 
-defmodule WebSockex.Conn.RequestError do
+defmodule WebSockex.RequestError do
   defexception [:code, :message]
 
   def message(%__MODULE__{code: code, message: message}) do

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -51,7 +51,6 @@ defmodule WebSockex.TestServer do
   def receive_socket_pid do
     receive do
       pid when is_pid(pid) -> pid
-      _ -> receive_socket_pid()
     after
       500 -> raise "No Server Socket pid"
     end

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -15,12 +15,17 @@ defmodule WebSockex.TestServer do
   def start(pid) when is_pid(pid) do
     ref = make_ref()
     port = get_port()
+    {:ok, agent_pid} = Agent.start_link(fn -> :ok end)
     url = "ws://localhost:#{port}/ws"
-    case Plug.Adapters.Cowboy.http(__MODULE__, [], [dispatch: dispatch(pid), port: port, ref: ref]) do
+
+    opts = [dispatch: dispatch({pid, agent_pid}),
+            port: port,
+            ref: ref]
+
+    case Plug.Adapters.Cowboy.http(__MODULE__, [], opts) do
       {:ok, _} ->
         {:ok, {ref, url}}
       {:error, :eaddrinuse} ->
-        IO.puts "Address #{port} in use!"
         start(pid)
     end
   end
@@ -29,7 +34,9 @@ defmodule WebSockex.TestServer do
     ref = make_ref()
     port = get_port()
     url = "wss://localhost:#{port}/ws"
-    opts = [dispatch: dispatch(pid),
+    {:ok, agent_pid} = Agent.start_link(fn -> :ok end)
+
+    opts = [dispatch: dispatch({pid, agent_pid}),
             certfile: @certfile,
             keyfile: @keyfile,
             port: port,
@@ -61,8 +68,8 @@ defmodule WebSockex.TestServer do
     [cert]
   end
 
-  defp dispatch(pid) do
-    [{:_, [{"/ws", WebSockex.TestSocket, [pid]}]}]
+  defp dispatch(tuple) do
+    [{:_, [{"/ws", WebSockex.TestSocket, [tuple]}]}]
   end
 
   defp get_port do
@@ -79,13 +86,20 @@ end
 defmodule WebSockex.TestSocket do
   @behaviour :cowboy_websocket_handler
 
-  def init(_, _, _) do
-    {:upgrade, :protocol, :cowboy_websocket}
+  def init(_, req, [{_, agent_pid}]) do
+    case Agent.get(agent_pid, fn x -> x end) do
+      :ok -> {:upgrade, :protocol, :cowboy_websocket}
+      int when is_integer(int) ->
+        :cowboy_req.reply(int, req)
+        {:shutdown, req, :tests_are_fun}
+    end
   end
 
-  def websocket_init(_, req, [pid]) do
+  def terminate(_,_,_), do: :ok
+
+  def websocket_init(_, req, [{pid, agent_pid}]) do
     send(pid, self())
-    {:ok, req, %{pid: pid}}
+    {:ok, req, %{pid: pid, agent_pid: agent_pid}}
   end
 
   def websocket_terminate({:remote, :closed}, _, state) do
@@ -126,6 +140,13 @@ defmodule WebSockex.TestSocket do
   end
   def websocket_info({:send, frame}, req, state) do
     {:reply, frame, req, state}
+  end
+  def websocket_info({:set_code, code}, req, state) do
+    Agent.update(state.agent_pid, fn _ -> code end)
+    {:ok, req, state}
+  end
+  def websocket_info(:shutdown, req, state) do
+    {:shutdown, req, state}
   end
   def websocket_info(_, req, state), do: {:ok, req, state}
 end

--- a/test/websockex/client_test.exs
+++ b/test/websockex/client_test.exs
@@ -488,7 +488,7 @@ defmodule WebSockex.ClientTest do
 
   test "Won't exit on a request error", context do
     assert TestClient.start_link(context.url <> "blah", %{}) ==
-      {:error, %WebSockex.Conn.RequestError{code: 404, message: "Not Found"}}
+      {:error, %WebSockex.RequestError{code: 404, message: "Not Found"}}
   end
 
   describe "default implementation errors" do

--- a/test/websockex/client_test.exs
+++ b/test/websockex/client_test.exs
@@ -512,13 +512,13 @@ defmodule WebSockex.ClientTest do
         TestClient.start_link(context.url <> "bad", %{bad_response: true})
     end
 
-    test "get invoked during init connection", context do
+    test "gets invoked during an init connect", context do
       assert {:error, _} = TestClient.start_link(context.url <> "bad", %{catch_connect_failure: self()})
 
       assert_receive :caught_connect_failure
     end
 
-    test "can attempt to reconnect during init connection", context do
+    test "can attempt to reconnect during an init connect", context do
       assert {:error, _} = TestClient.start_link(context.url <> "bad", %{attempt_reconnect: self()})
 
       assert_received {:retry_connect, %{conn: %WebSockex.Conn{}, error: %{code: 404}, attempt_number: 1}}
@@ -528,7 +528,7 @@ defmodule WebSockex.ClientTest do
       assert_received {:stopping_retry, %{conn: %WebSockex.Conn{}, error: %{code: 404}, attempt_number: 3}}
     end
 
-    test "can reconnect with a new conn object on reconnect", context do
+    test "can reconnect with a new conn object during an init reconnect", context do
       state_map = %{attempt_reconnect: self(), good_url: context.url, catch_text: self()}
       assert {:ok, _} = TestClient.start_link(context.url <> "bad", state_map)
       server_pid = WebSockex.TestServer.receive_socket_pid()

--- a/test/websockex/conn_test.exs
+++ b/test/websockex/conn_test.exs
@@ -55,7 +55,7 @@ defmodule WebSockex.ConnTest do
     :ok = WebSockex.Conn.socket_send(conn, request)
 
     assert WebSockex.Conn.handle_response(conn) ==
-      {:error, %WebSockex.Conn.RequestError{code: 400, message: "Bad Request"}}
+      {:error, %WebSockex.RequestError{code: 400, message: "Bad Request"}}
   end
 
   describe "secure connection" do


### PR DESCRIPTION
`handle_connect_failure` was added to handle the cases where one would want to handle connection failures after trying to connect.

For example, trying to reconnect indefinitely like in #5 could be accomplished with

```elixir
def handle_connect_failure(_failure_map, state) do
  {:reconnect, state}
end
```

But you could also [change the where you are trying to connect to entirely][1] or just update some parts of the `conn` returned in the `failure_map`.

[1]: https://github.com/Azolo/websockex/blob/c7b036cf048f6b78460a5912fead0eaa1c9cd6fe/test/websockex/client_test.exs#L114-L119 