### PR TITLE
Fixed return of `send_frame`.

### DIFF
--- a/lib/websockex/client.ex
+++ b/lib/websockex/client.ex
@@ -275,8 +275,10 @@ defmodule WebSockex.Client do
   """
   @spec send_frame(pid, frame) :: :ok | {:error, WebSockex.FrameEncodeError.t}
   def send_frame(pid, frame) do
-    with {:ok, binary_frame} <- WebSockex.Frame.encode_frame(frame),
-    do: send(pid, {:"$websockex_send", binary_frame})
+    with {:ok, binary_frame} <- WebSockex.Frame.encode_frame(frame) do
+      send(pid, {:"$websockex_send", binary_frame})
+      :ok
+    end
   end
 
   @doc false


### PR DESCRIPTION
It is stated that return will be `:ok | {:error, WebSockex.FrameEncodeError.t}` but it couldnt have been `:ok`.

The return value will be from taken `send`, which will return the send message by default. Using a hardcoded `:ok` should fix this.