### PR TITLE
Rework Reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   - `handle_disconnect` now has another return option for when wanted to
     reconnect with different URI options or headers:
     `{:reconnect, new_conn, new_state}`
-  - Added the `:retry` option to the options for `start` and `start_link` that
-    will allow `handle_disconnect` to be called if we can establish a
-    connection during those functions.
+  - Added the `:handle_initial_conn_failure` option to the options for `start`
+    and `start_link` that will allow `handle_disconnect` to be called if we can
+    establish a connection during those functions.
   - Removed `handle_connect_failure` entirely.
 
 ## 0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## Unreleased
 - Add `Client.start` for non-linked processes.
 - Add `async` option to `start` and `start_link`.
+- Roll `handle_connect_failure` functionality into `handle_disconnect`.
+  - The first parameter of `handle_disconnect` is now a map with the keys:
+    `:reason`, `:conn`, and `:attempt_number`.
+  - `handle_disconnect` now has another return option for when wanted to
+    reconnect with different URI options or headers:
+    `{:reconnect, new_conn, new_state}`
+  - Added the `:retry` option to the options for `start` and `start_link` that
+    will allow `handle_disconnect` to be called if we can establish a
+    connection during those functions.
+  - Removed `handle_connect_failure` entirely.
 
 ## 0.1.3
 - `Client.start_link` will no longer cause the calling process to exit on

--- a/test/websockex/client_test.exs
+++ b/test/websockex/client_test.exs
@@ -97,7 +97,7 @@ defmodule WebSockex.ClientTest do
     end
 
     def handle_disconnect(_, %{catch_init_connect_failure: pid} = state) do
-      send(pid, :caught_init_connect_failure)
+      send(pid, :caught_initial_conn_failure)
       {:ok, state}
     end
     def handle_disconnect(%{attempt_number: 3} = failure_map, %{multiple_reconnect: pid} = state) do
@@ -611,13 +611,13 @@ defmodule WebSockex.ClientTest do
                                                  %{catch_init_connect_failure: self()},
                                                  handle_initial_conn_failure: true)
 
-      assert_receive :caught_init_connect_failure
+      assert_receive :caught_initial_conn_failure
     end
 
     test "doesn't get invoked during init without retry", context do
       assert {:error, _} = TestClient.start_link(context.url <> "bad", %{catch_init_connect_failure: self()})
 
-      refute_receive :caught_init_connect_failure
+      refute_receive :caught_initial_conn_failure
     end
 
     test "can attempt to reconnect during an init connect", context do

--- a/test/websockex/client_test.exs
+++ b/test/websockex/client_test.exs
@@ -606,10 +606,10 @@ defmodule WebSockex.ClientTest do
       assert_receive :caught_disconnect
     end
 
-    test "gets invoked during init with retry", context do
+    test "gets invoked during init with handle_initial_conn_failure", context do
       assert {:error, _} = TestClient.start_link(context.url <> "bad",
                                                  %{catch_init_connect_failure: self()},
-                                                 retry: true)
+                                                 handle_initial_conn_failure: true)
 
       assert_receive :caught_init_connect_failure
     end
@@ -621,7 +621,9 @@ defmodule WebSockex.ClientTest do
     end
 
     test "can attempt to reconnect during an init connect", context do
-      assert {:error, _} = TestClient.start_link(context.url <> "bad", %{multiple_reconnect: self()}, retry: true)
+      assert {:error, _} = TestClient.start_link(context.url <> "bad",
+                                                 %{multiple_reconnect: self()},
+                                                 handle_initial_conn_failure: true)
 
       assert_received {:retry_connect, %{conn: %WebSockex.Conn{}, reason: %{code: 404}, attempt_number: 1}}
       assert_received {:check_retry_state, %{attempt: 1}}
@@ -632,7 +634,7 @@ defmodule WebSockex.ClientTest do
 
     test "can reconnect with a new conn struct during an init reconnect", context do
       state_map = %{change_conn_reconnect: self(), good_url: context.url, catch_text: self()}
-      assert {:ok, _} = TestClient.start_link(context.url <> "bad", state_map, retry: true)
+      assert {:ok, _} = TestClient.start_link(context.url <> "bad", state_map, handle_initial_conn_failure: true)
       server_pid = WebSockex.TestServer.receive_socket_pid()
 
       assert_received :retry_change_conn


### PR DESCRIPTION
I really didn't like the extra callback for reconnecting multiple times.

It felt inconsistent to use `handle_connect_failure` only after a reconnect failed. What if you wanted to reconnect with different headers or needed to change the url completely. You could only do that after failing to reconnect once.

I could have changed it so that you could use a different return tuple for `handle_disconnect` to make to skip directly to `handle_connect_failure` but that seems really dumb.

So, I just changed `handle_disconnect` to act more like `handle_connect_failure`, then ditched `handle_connect_failure` completely. Then I added a `retry: true` option to `start` and `start_link` that will cause `handle_disconnect` to be invoked when a connection fails to be established.

I'm probably going to wait a day or two to see if I can come up with anything better than the `:retry` option name. It's misleading to say that we are retrying, instead just allowing the ability to try and reconnect through the `handle_disconnect` callback.