### PR TITLE
Handle System Messages while opening a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - `:socket_connect_timeout` - The timeout for opening a TCP connection.
   - `:socket_recv_timeout` - The timeout for receiving a HTTP response header.
 - `start` and `start_link` can now take a `Conn` struct in place of a url.
+- Added the ability to handle system messages while opening a connection.
+- Added the ability to handle parent exit messages while opening a connection.
+- Improve `:sys.get_status`, `:sys.get_state`, `:sys.replace_state` functions.
+  - These are undocumented, but are meant primarly for debugging.
 
 ### Bug Fixes
 - Ensure `terminate/2` callback is called consistently.

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -352,13 +352,13 @@ defmodule WebSockex do
 
   @doc false
   def system_get_state(state) do
-    {:ok, state, state}
+    {:ok, state}
   end
 
   @doc false
   def system_replace_state(fun, state) do
-    new_state = fun.(state)
-    {:ok, new_state, new_state}
+    new_module_state = fun.(state.module_state)
+    {:ok, new_module_state, %{state | module_state: new_module_state}}
   end
 
   @doc false

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -456,6 +456,14 @@ defmodule WebSockex do
       {:system, from, req} ->
         state = Map.put(state, :connection_status, :connecting)
         :sys.handle_system_msg(req, from, parent, __MODULE__, debug, state)
+      {:EXIT, ^parent, reason} ->
+        case state do
+          %{reply_fun: reply_fun} ->
+            reply_fun.(reason)
+            exit(reason)
+          _ ->
+            terminate(reason, parent, debug, state)
+        end
       {^ref, {:ok, new_conn}} ->
         Process.demonitor(ref, [:flush])
         new_state = Map.delete(state, :task)

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -351,8 +351,8 @@ defmodule WebSockex do
   end
 
   @doc false
-  def system_get_state(state) do
-    {:ok, state}
+  def system_get_state(%{module_state: module_state}) do
+    {:ok, module_state}
   end
 
   @doc false

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -599,8 +599,7 @@ defmodule WebSockex do
     case result do
       {:ok, new_module_state} ->
          state.reply_fun.({:ok, self()})
-         state = Map.merge(state, %{
-                                    module_state: new_module_state})
+         state = Map.put(state, :module_state, new_module_state)
                  |> Map.delete(:reply_fun)
 
           websocket_loop(parent, debug, state)

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -372,6 +372,20 @@ defmodule WebSockex do
     other -> other
   end
 
+  @doc false
+  def format_status(_, [_pdict, sys_state, parent, debug, state]) do
+    log = :sys.get_debug(:log, debug, [])
+
+    [header: "Status for WebSockex process #{inspect self()}",
+     data: [{"Status", sys_state},
+            {"Parent", parent},
+            {"Log", log},
+            {"Connection Status", "Connected"},
+            {"Socket Buffer", state.buffer},
+            {"Socket Module", state.module},
+            {"State", state.module_state}]]
+  end
+
   # Internals! Yay
 
   defp on_disconnect(reason, parent, debug, state, callbacks \\ [], attempt \\ 1) do

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -347,7 +347,7 @@ defmodule WebSockex do
     websocket_loop(parent, debug, Map.delete(state, :connection_status))
   end
   def system_continue(parent, debug, %{connection_status: :connecting} = state) do
-    open_connection_loop(parent, debug, Map.delete(state, :connection_status))
+    open_loop(parent, debug, Map.delete(state, :connection_status))
   end
 
   @doc false
@@ -447,10 +447,10 @@ defmodule WebSockex do
         {:ok, conn}
       end
     end)
-    open_connection_loop(parent, debug, Map.put(state, :task, task))
+    open_loop(parent, debug, Map.put(state, :task, task))
   end
 
-  defp open_connection_loop(parent, debug, state) do
+  defp open_loop(parent, debug, state) do
     %{task: %{ref: ref}} = state
     receive do
       {:system, from, req} ->

--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -428,7 +428,15 @@ defmodule WebSockex do
         {:ok, conn}
       end
     end)
-    Task.await(task, :infinity) # Timeouts built into the task
+    open_connection_loop(task)
+  end
+
+  defp open_connection_loop(%{ref: ref}) do
+    receive do
+      {^ref, res} ->
+        Process.demonitor(ref, [:flush])
+        res
+    end
   end
 
   defp validate_handshake(headers, key) do

--- a/lib/websockex/conn.ex
+++ b/lib/websockex/conn.ex
@@ -190,6 +190,14 @@ defmodule WebSockex.Conn do
     :ssl.setopts(conn.socket, active: val)
   end
 
+  @doc """
+  Set the socket's controlling process.
+  """
+  @spec controlling_process(__MODULE__.t, new_owner :: pid) :: :ok | {:error, term}
+  def controlling_process(conn, new_owner) do
+    conn.conn_mod.controlling_process(conn.socket, new_owner)
+  end
+
   defp transport(:gen_tcp), do: :tcp
   defp transport(:ssl), do: :ssl
 

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -46,7 +46,8 @@ defmodule WebSockex.TestServer do
       {:ok, _} ->
         {:ok, {ref, url}}
       {:error, :eaddrinuse} ->
-        IO.puts "Address #{port} in use!"
+        require Logger
+        Logger.error "Address #{port} in use!"
         start_https(pid)
     end
   end

--- a/test/websockex/conn_test.exs
+++ b/test/websockex/conn_test.exs
@@ -172,4 +172,16 @@ defmodule WebSockex.ConnTest do
     assert request =~ ~r(X-Test: Shoes\r\n)
     assert request =~ ~r(\r\n\r\n\z)
   end
+
+  test "controlling_process", %{conn: conn} do
+    socket = conn.socket
+    # Start a random process
+    {:ok, agent_pid} = Agent.start_link(fn -> :test end)
+
+    assert :erlang.port_info(socket, :connected) == {:connected, self()}
+
+    WebSockex.Conn.controlling_process(conn, agent_pid)
+
+    assert :erlang.port_info(socket, :connected) == {:connected, agent_pid}
+  end
 end

--- a/test/websockex_test.exs
+++ b/test/websockex_test.exs
@@ -927,6 +927,8 @@ defmodule WebSockexTest do
     end
   end
 
+  ## OTP Stuffs (That I know how to test)
+
   describe "OTP Compliance" do
     test "requires the child to exit when receiving a parent exit signal", context do
       Process.flag(:trap_exit, true)
@@ -936,5 +938,12 @@ defmodule WebSockexTest do
 
       assert_receive {:EXIT, ^pid, "OTP Compliance Test"}
     end
+  end
+
+  test "system_replace_state only replaces module_state", context do
+    :sys.replace_state(context.pid, fn(_) -> :lemon end)
+    WebSockex.cast(context.pid, {:get_state, self()})
+
+    assert_receive :lemon
   end
 end

--- a/test/websockex_test.exs
+++ b/test/websockex_test.exs
@@ -940,14 +940,14 @@ defmodule WebSockexTest do
     end
   end
 
-  test "system_replace_state only replaces module_state", context do
+  test ":sys.replace_state only replaces module_state", context do
     :sys.replace_state(context.pid, fn(_) -> :lemon end)
     WebSockex.cast(context.pid, {:get_state, self()})
 
     assert_receive :lemon
   end
 
-  test "system_get_state only returns module_state", context do
+  test ":sys.get_state only returns module_state", context do
     get_state = :sys.get_state(context.pid)
 
     WebSockex.cast(context.pid, {:get_state, self()})

--- a/test/websockex_test.exs
+++ b/test/websockex_test.exs
@@ -954,4 +954,12 @@ defmodule WebSockexTest do
 
     assert_receive ^get_state
   end
+
+  test ":sys.get_status returns from format_status", context do
+    {:data, data} = elem(:sys.get_status(context.pid), 3)
+                    |> List.flatten
+                    |> List.keyfind(:data, 0)
+
+    assert {"Connection Status", "Connected"} in data
+  end
 end

--- a/test/websockex_test.exs
+++ b/test/websockex_test.exs
@@ -946,4 +946,12 @@ defmodule WebSockexTest do
 
     assert_receive :lemon
   end
+
+  test "system_get_state only returns module_state", context do
+    get_state = :sys.get_state(context.pid)
+
+    WebSockex.cast(context.pid, {:get_state, self()})
+
+    assert_receive ^get_state
+  end
 end


### PR DESCRIPTION
This started as just trying to use a separate process for so that I could try to use a `GenServer` and keep my current functionality.

But then I realized that we would process messages without being connected. This wasn't something I wanted. But, as a result of that work we get a nice benefit in we can handle messages while connecting.

I don't want to change the API too much right now, but it's a step closer to being able to send some synchronous messages without timing out from a infinite trying to connect cycle.

Also, I updated a lot of the functions that the `:sys` module uses.
