### PR TITLE
Set active after switching controlling process

### DIFF
--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -659,9 +659,9 @@ defmodule WebSockex do
            :ok <- WebSockex.Conn.socket_send(conn, request),
            {:ok, headers} <- WebSockex.Conn.handle_response(conn),
            :ok <- validate_handshake(headers, key),
-           :ok <- WebSockex.Conn.set_active(conn)
+           :ok <- WebSockex.Conn.controlling_process(conn, my_pid)
       do
-        :ok = WebSockex.Conn.controlling_process(conn, my_pid)
+        :ok = WebSockex.Conn.set_active(conn)
         {:ok, conn}
       end
     end)


### PR DESCRIPTION
A good portion of the time the `handle_frame/2` callback would never be called. I tracked it down to the controlling process not receiving any messages, causing a hangup [here](https://github.com/Azolo/websockex/blob/master/lib/websockex.ex#L434).

I'm not too familiar with the inner workings of `gen_tcp` but it seems as though setting the socket to active before switching the controlling process causes some messages to end up in the wrong mailbox. There's a bit of discussion on a similar issue [here](https://stackoverflow.com/questions/11409656/erlang-avoiding-race-condition-with-gen-tcpcontrolling-process).

If I'm mistaken about something, please let me know as my knowledge of Erlang in general could use some work!