### PR TITLE
Add reply response to example

### DIFF
--- a/examples/echo_client.exs
+++ b/examples/echo_client.exs
@@ -12,12 +12,6 @@ defmodule EchoClient do
     WebSockex.send_frame(client, {:text, message})
   end
 
-  @spec send_frame(pid, WebSockex.frame) :: :ok
-  def send_frame(pid, {:text, msg} = frame) do
-    Logger.info("Sending message: #{msg}")
-    WebSockex.send_frame(pid, frame)
-  end
-
   def handle_connect(_conn, state) do
     Logger.info("Connected!")
     {:ok, state}
@@ -49,12 +43,12 @@ end
 
 {:ok, pid} = EchoClient.start_link()
 
-EchoClient.send_frame(pid, {:text, "Yo Homies!"})
-EchoClient.send_frame(pid, {:text, "This and That!"})
-EchoClient.send_frame(pid, {:text, "Can you please reply yourself?"})
+EchoClient.echo(pid, "Yo Homies!")
+EchoClient.echo(pid, "This and That!")
+EchoClient.echo(pid, "Can you please reply yourself?")
 
 Process.sleep 1000
 
-EchoClient.send_frame(pid, {:text, "Close the things!"})
+EchoClient.echo(pid, "Close the things!")
 
 Process.sleep 1500

--- a/examples/echo_client.exs
+++ b/examples/echo_client.exs
@@ -18,6 +18,17 @@ defmodule EchoClient do
     WebSockex.send_frame(pid, frame)
   end
 
+  def handle_connect(_conn, state) do
+    Logger.info("Connected!")
+    {:ok, state}
+  end
+
+  def handle_frame({:text, "Can you please reply yourself?" = msg}, :fake_state) do
+    Logger.info("Received Message: #{msg}")
+    msg = "Sure can!"
+    Logger.info("Sending message: #{msg}")
+    {:reply, {:text, msg}, :fake_state}
+  end
   def handle_frame({:text, "Close the things!" = msg}, :fake_state) do
     Logger.info("Received Message: #{msg}")
     {:close, :fake_state}
@@ -40,8 +51,9 @@ end
 
 EchoClient.send_frame(pid, {:text, "Yo Homies!"})
 EchoClient.send_frame(pid, {:text, "This and That!"})
+EchoClient.send_frame(pid, {:text, "Can you please reply yourself?"})
 
-Process.sleep 500
+Process.sleep 1000
 
 EchoClient.send_frame(pid, {:text, "Close the things!"})
 


### PR DESCRIPTION
Based on the discussion from https://github.com/Azolo/websockex/issues/34, I've tweaked the example a bit to make use of the `{:reply, frame, state}` response and have also added a `handle_connect/2` callback just for the heck of it. When making those changes I noticed two versions of a public-API-like function (`send_frame/2` and the more user-friendly `echo/2`). To declutter I dropped `send_frame/2` and adjusted the example accordingly. I did the change as separate commits, so feel free to cherry-pick if you don't want the latter. Thanks again for the prompt response and explanation! 👍 