### PR TITLE
Handle :ssl_closed instead of passing through to handle_info/2

### DIFF
--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -534,6 +534,8 @@ defmodule WebSockex do
             websocket_loop(parent, debug, %{state | buffer: buffer})
           {:tcp_closed, ^socket} ->
             handle_close({:remote, :closed}, parent, debug, state)
+          {:ssl_closed, ^socket} ->
+            handle_close({:remote, :closed}, parent, debug, state)
           {:EXIT, ^parent, reason} ->
             terminate(reason, parent, debug, state)
           msg ->


### PR DESCRIPTION
Fixes :ssl_closed never being handled and being passed through to the handle_info/2 callback instead. 

Edit for more info: When connecting to an SSL websocket (wss://), a disconnect will send :ssl_closed instead of :tcp_closed. This wasn't handled in WebSockex itself, and so it was being passed through to the handle_info/2 callback, which I presume isn't quite the right behaviour. 