### PR TITLE
allow custom ssl options

### DIFF
--- a/lib/websockex/conn.ex
+++ b/lib/websockex/conn.ex
@@ -22,7 +22,8 @@ defmodule WebSockex.Conn do
             socket_recv_timeout: @socket_recv_timeout_default,
             cacerts: nil,
             insecure: true,
-            resp_headers: []
+            resp_headers: [],
+            ssl_options: nil
 
   @type socket :: :gen_tcp.socket() | :ssl.sslsocket()
   @type header :: {field :: String.t(), value :: String.t()}
@@ -91,7 +92,8 @@ defmodule WebSockex.Conn do
       insecure: Keyword.get(opts, :insecure, true),
       socket_connect_timeout:
         Keyword.get(opts, :socket_connect_timeout, @socket_connect_timeout_default),
-      socket_recv_timeout: Keyword.get(opts, :socket_recv_timeout, @socket_recv_timeout_default)
+      socket_recv_timeout: Keyword.get(opts, :socket_recv_timeout, @socket_recv_timeout_default),
+      ssl_options: Keyword.get(opts, :ssl_options, nil)
     }
   end
 
@@ -314,6 +316,15 @@ defmodule WebSockex.Conn do
   end
 
   # Crazy SSL Stuff (It will be normal SSL stuff when I figure out Erlang's ssl)
+
+  defp ssl_connection_options(%{ssl_options: ssl_options}) when not is_nil(ssl_options) do
+    [
+      mode: :binary,
+      active: false,
+      packet: 0
+    ]
+    |> Keyword.merge(ssl_options)
+  end
 
   defp ssl_connection_options(%{insecure: true}) do
     [

--- a/test/websockex/conn_test.exs
+++ b/test/websockex/conn_test.exs
@@ -175,6 +175,18 @@ defmodule WebSockex.ConnTest do
       Process.sleep(50)
       assert {:error, _} = :ssl.sockname(socket)
     end
+
+    test "open_socket with custom ssl options", context do
+      ssl_options = [cacertfile: Path.join([__DIR__, "..", "support", "priv", "websockexca.cer"])]
+      conn = WebSockex.Conn.new(context.uri, ssl_options: ssl_options)
+
+      assert {:ok,
+              %WebSockex.Conn{
+                conn_mod: :ssl,
+                transport: :ssl,
+                ssl_options: ^ssl_options
+              }} = WebSockex.Conn.open_socket(conn)
+    end
   end
 
   test "close_socket", context do


### PR DESCRIPTION
this PR contains the simple change which i've mentioned over at #33. for a connection which uses client certificates, that would be for example:

```elixir
{:ok, _} = WebSockex.start_link(
  WebSockex.Conn.new(
    "wss://host/path",
    ssl_options: [
      cacertfile: "/certificates/ca.pem",
      certfile: "/certificates/cert.pem",
      keyfile: "/certificates/key.pem"
    ]
  ),
  __MODULE__,
  :fake_state
)
```