### PR TITLE
Fix deprecation warning in Elixir 1.8

### DIFF
--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -50,7 +50,7 @@ defmodule WebSockex do
   @type frame ::
           :ping
           | :pong
-          | {:ping | :pong, nil | message :: binary}
+          | {:ping | :pong, nil | (message :: binary)}
           | {:text | :binary, message :: binary}
 
   @typedoc """


### PR DESCRIPTION
Because it would show this warning before:

```
==> websockex
Compiling 6 files (.ex)
warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: nil | message :: binary
  lib/websockex.ex:50
```