### PR TITLE
Add an example for authentication

### DIFF
--- a/examples/auth_headers.ex
+++ b/examples/auth_headers.ex
@@ -1,0 +1,18 @@
+defmodule AuthHeaders do
+  use WebSockex
+
+  @moduledoc ~S"""
+  Sample usage connecting to server using authorization.
+  You can specify `extra_headers` in as fourth parameter to
+  `WebSockex.start_link/4` which then will be used build
+  connection to websocket server.
+  """
+     
+  def start_link(url, state) do
+    extra_headers = [
+      {"Authorization", "JWT ..."}
+    ]
+
+    WebSockex.start_link(url, __MODULE__, state, extra_headers: extra_headers)
+  end
+end


### PR DESCRIPTION
Hey,

In this PR only an example was added to show how users can use `extra_headers` to authenticate on the server using JWT or basic auth.