### PR TITLE
add reply tuple as handle_connect return type in typespec

### DIFF
--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -143,7 +143,10 @@ defmodule WebSockex do
 
   This is invoked after both the initial connection and a reconnect.
   """
-  @callback handle_connect(conn :: WebSockex.Conn.t(), state :: term) :: {:ok, new_state :: term}
+  @callback handle_connect(conn :: WebSockex.Conn.t(), state :: term) ::
+              {:ok, new_state}
+              | {:reply, frame, new_state}
+            when new_state: term
 
   @doc """
   Invoked on the reception of a frame on the socket.


### PR DESCRIPTION
Thank you very much for this amazing ws client library. I found a minor issue about typespec.

Returning `{:reply, }` is supported by current code base but it's missing from typespec. This is also a pretty common pattern that we want to send msg to targeted ws server after it's reconnected.

Note that `{:close, new_state} | {:close, close_frame, new_state}` should be possible return type but I don't see any possible use case of using it in `handle_connect` so I didn't add them to possible return type.
