### PR TITLE
Telemetry events

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ application tree. This is generally a good piece of advice for any process, howe
 bevhaviour can be written as a self-sustaining tcp connection. I feel like it is even more important to express this
 particular piece of advice here.
 
+## Telemetry
+
+Websockex clients emit the following telemetry events:
+
+* `[:websockex, :connect]`
+* `[:websockex, :disconnect]`
+* `[:websockex, :frame, :received]`
+* `[:websockex, :frame, :sent]`
+* `[:websockex, :terminate]`
+
+For all these events, the measurements is `%{time: System.system_time()}` and they all share common metadata as a map containing the `:conn`, `:pid`, `:module` keys. For frame events, the metadata also contains the `:frame` key. For disconnections and terminations, it will contain the `:reason` key. 
+
+
 ## Tips
 ### Terminating with :normal after an Exceptional Close or Error
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,14 +22,15 @@ defmodule WebSockex.Mixfile do
   defp elixirc_paths(_), do: ['lib']
 
   def application do
-    [applications: [:logger, :ssl, :crypto], mod: {WebSockex.Application, []}]
+    [applications: [:logger, :ssl, :crypto, :telemetry], mod: {WebSockex.Application, []}]
   end
 
   defp deps do
     [
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:cowboy, "~> 1.0.0", only: :test},
-      {:plug, "~> 1.0", only: :test}
+      {:plug, "~> 1.0", only: :test},
+      {:telemetry, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm", "33dd09e615daab5668c15cc3a33829892728fdbed910ab0c0a0edb06b45fc54d"},
   "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "fd5244357e6d5651d3e1bc3582f5e29c29f5055f34194533100ececc2dfae2fd"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm", "6e56493a862433fccc3aca3025c946d6720d8eedf6e3e6fb911952a7071c357f"},
+  "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
 }


### PR DESCRIPTION
This PR adds telemetry to the library. For now, the following basic events are emitted:

* `[:websockex, :connect]`
* `[:websockex, :disconnect]`
* `[:websockex, :frame, :received]`
* `[:websockex, :frame, :sent]`
* `[:websockex, :terminate]`

All telemetry tests are in a separate `describe` block. In order to be able to test the `:terminate` event properly, I had to replace the default, linked test client by a non-linked one. Hence the `:skip_default_client` describetag.

Fixes #99 