### PR TITLE
Fix echo client example

### DIFF
--- a/examples/echo_client.exs
+++ b/examples/echo_client.exs
@@ -3,7 +3,7 @@ defmodule EchoClient do
   require Logger
 
   def start_link(opts \\ []) do
-    WebSockex.start_link("wss://echo.websocket.org/?encoding=text", __MODULE__, :fake_state, opts)
+    WebSockex.start_link("wss://ws.postman-echo.com/raw", __MODULE__, :fake_state, opts)
   end
 
   @spec echo(pid, String.t) :: :ok


### PR DESCRIPTION
The echo.websocket.org service is no longer available, unfortunately. 

To fix this example that is quite useful to learn, we could switch the example service to the [Postman echo service](https://blog.postman.com/introducing-postman-websocket-echo-service/), as it works just the same.  