### PR TITLE
Update the echo server URL

### DIFF
--- a/examples/echo_client.exs
+++ b/examples/echo_client.exs
@@ -3,7 +3,7 @@ defmodule EchoClient do
   require Logger
 
   def start_link(opts \\ []) do
-    WebSockex.start_link("wss://echo.websocket.org/?encoding=text", __MODULE__, :fake_state, opts)
+    WebSockex.start_link("wss://echo.websocket.events/?encoding=text", __MODULE__, :fake_state, opts)
   end
 
   @spec echo(pid, String.t) :: :ok


### PR DESCRIPTION
According to [this article](https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative) the server at `echo.websocket.org` was shut down in 2021. The author provides an alternative echo server URL, used here.

See also [this Elixir forum thread](https://elixirforum.com/t/matcherror-no-match-of-right-hand-side-value-error-websockex-requesterror-code-200-message-ok/51900) where the issue was originally reported.