### PR TITLE
Use `__STACKTRACE__` to fetch stacktrace in callbacks

### DIFF
--- a/lib/websockex.ex
+++ b/lib/websockex.ex
@@ -1129,7 +1129,7 @@ defmodule WebSockex do
     apply(module, function, args)
   catch
     :error, payload ->
-      stacktrace = System.stacktrace()
+      stacktrace = __STACKTRACE__
       reason = Exception.normalize(:error, payload, stacktrace)
       {:"$EXIT", {reason, stacktrace}}
 


### PR DESCRIPTION
On `System.stacktrace()` is deprecated now and always returns `[]` @Azolo 