### PR TITLE
convert bxor references to Bitwise library

### DIFF
--- a/lib/websockex/frame.ex
+++ b/lib/websockex/frame.ex
@@ -391,13 +391,13 @@ defmodule WebSockex.Frame do
 
   for x <- 1..3 do
     defp mask(<<key::8*unquote(x), _::binary>>, <<part::8*unquote(x)>>, acc) do
-      masked = bxor(part, key)
+      masked = Bitwise.bxor(part, key)
       <<acc::binary, masked::8*unquote(x)>>
     end
   end
 
   defp mask(<<key::32>> = key_bin, <<part::8*4, rest::binary>>, acc) do
-    masked = bxor(part, key)
+    masked = Bitwise.bxor(part, key)
     mask(key_bin, rest, <<acc::binary, masked::8*4>>)
   end
 end


### PR DESCRIPTION
getting a warning that bxor should be Bitwise.bxor, here is a PR to effect that.