### PR TITLE
rfc7230: Port number in Host header when not std.

### DIFF
--- a/lib/websockex/conn.ex
+++ b/lib/websockex/conn.ex
@@ -201,9 +201,16 @@ defmodule WebSockex.Conn do
   """
   @spec build_request(__MODULE__.t(), key :: String.t()) :: {:ok, String.t()}
   def build_request(conn, key) do
+    host =
+      if conn.port in [80, 443] do
+        conn.host
+      else
+        "#{conn.host}:#{conn.port}"
+      end
+
     headers =
       ([
-         {"Host", conn.host},
+         {"Host", host},
          {"Connection", "Upgrade"},
          {"Upgrade", "websocket"},
          {"Sec-WebSocket-Version", "13"},


### PR DESCRIPTION
I ran into a problem of getting a "Forbidden" return on a `ws://localhost:9944` service when using websockex while connecting with wscat worked fine. After inspecting the wire communication with `tcpdump` I found that wscat was always sending the port number in the communication: `Host: localhost:9944` while websockex did not include it and just submitted `Host: localhost` -- The service was checking that hostname and did not allow any connections not matching the hostname + port.

After checking rfc7230 on this it seems appending the port number is in fact the right thing to do when the port number is different from the default port of the scheme (http/ws=80 and https/wss=443).

This patch fixes the issue and gets us nearer to rfc7230 conformance.