### PR TITLE
Pin variables used in match (for elixir 1.20)

### DIFF
--- a/lib/websockex/frame.ex
+++ b/lib/websockex/frame.ex
@@ -106,7 +106,7 @@ defmodule WebSockex.Frame do
       )
       when close_code in 1000..4999 do
     size = len - 2
-    <<payload::bytes-size(size), rest::bitstring>> = remaining
+    <<payload::bytes-size(^size), rest::bitstring>> = remaining
 
     if String.valid?(payload) do
       {:ok, {:close, close_code, payload}, rest}
@@ -122,7 +122,7 @@ defmodule WebSockex.Frame do
   # Ping and Pong with Payloads
   for {key, opcode} <- Map.take(@opcodes, [:ping, :pong]) do
     def parse_frame(<<1::1, 0::3, unquote(opcode)::4, 0::1, len::7, remaining::bitstring>>) do
-      <<payload::bytes-size(len), rest::bitstring>> = remaining
+      <<payload::bytes-size(^len), rest::bitstring>> = remaining
       {:ok, {unquote(key), payload}, rest}
     end
   end
@@ -142,17 +142,17 @@ defmodule WebSockex.Frame do
 
   # Binary Frames
   def parse_frame(<<1::1, 0::3, 2::4, 0::1, 126::7, len::16, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:binary, payload}, rest}
   end
 
   def parse_frame(<<1::1, 0::3, 2::4, 0::1, 127::7, len::64, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:binary, payload}, rest}
   end
 
   def parse_frame(<<1::1, 0::3, 2::4, 0::1, len::7, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:binary, payload}, rest}
   end
 
@@ -161,52 +161,52 @@ defmodule WebSockex.Frame do
     def parse_frame(
           <<0::1, 0::3, unquote(opcode)::4, 0::1, 126::7, len::16, remaining::bitstring>>
         ) do
-      <<payload::bytes-size(len), rest::bitstring>> = remaining
+      <<payload::bytes-size(^len), rest::bitstring>> = remaining
       {:ok, {:fragment, unquote(key), payload}, rest}
     end
 
     def parse_frame(
           <<0::1, 0::3, unquote(opcode)::4, 0::1, 127::7, len::64, remaining::bitstring>>
         ) do
-      <<payload::bytes-size(len), rest::bitstring>> = remaining
+      <<payload::bytes-size(^len), rest::bitstring>> = remaining
       {:ok, {:fragment, unquote(key), payload}, rest}
     end
 
     def parse_frame(<<0::1, 0::3, unquote(opcode)::4, 0::1, len::7, remaining::bitstring>>) do
-      <<payload::bytes-size(len), rest::bitstring>> = remaining
+      <<payload::bytes-size(^len), rest::bitstring>> = remaining
       {:ok, {:fragment, unquote(key), payload}, rest}
     end
   end
 
   # Parse Fragmentation Continuation Frames
   def parse_frame(<<0::1, 0::3, 0::4, 0::1, 126::7, len::16, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:continuation, payload}, rest}
   end
 
   def parse_frame(<<0::1, 0::3, 0::4, 0::1, 127::7, len::64, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:continuation, payload}, rest}
   end
 
   def parse_frame(<<0::1, 0::3, 0::4, 0::1, len::7, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:continuation, payload}, rest}
   end
 
   # Parse Fragmentation Finish Frames
   def parse_frame(<<1::1, 0::3, 0::4, 0::1, 126::7, len::16, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:finish, payload}, rest}
   end
 
   def parse_frame(<<1::1, 0::3, 0::4, 0::1, 127::7, len::64, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:finish, payload}, rest}
   end
 
   def parse_frame(<<1::1, 0::3, 0::4, 0::1, len::7, remaining::bitstring>>) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
     {:ok, {:finish, payload}, rest}
   end
 
@@ -355,7 +355,7 @@ defmodule WebSockex.Frame do
   def encode_frame(frame), do: {:error, %WebSockex.InvalidFrameError{frame: frame}}
 
   defp parse_text_payload(len, remaining, buffer) do
-    <<payload::bytes-size(len), rest::bitstring>> = remaining
+    <<payload::bytes-size(^len), rest::bitstring>> = remaining
 
     if String.valid?(payload) do
       {:ok, {:text, payload}, rest}

--- a/test/websockex/frame_test.exs
+++ b/test/websockex/frame_test.exs
@@ -344,7 +344,7 @@ defmodule WebSockex.FrameTest do
 
       assert {:ok,
               <<1::1, 0::3, 9::4, 1::1, ^len::7, mask::bytes-size(4),
-                masked_payload::binary-size(len)>>} = Frame.encode_frame({:ping, payload})
+                masked_payload::binary-size(^len)>>} = Frame.encode_frame({:ping, payload})
 
       assert unmask(mask, masked_payload) == payload
     end
@@ -359,7 +359,7 @@ defmodule WebSockex.FrameTest do
 
       assert {:ok,
               <<1::1, 0::3, 10::4, 1::1, ^len::7, mask::bytes-size(4),
-                masked_payload::binary-size(len)>>} = Frame.encode_frame({:pong, payload})
+                masked_payload::binary-size(^len)>>} = Frame.encode_frame({:pong, payload})
 
       assert unmask(mask, masked_payload) == payload
     end
@@ -374,7 +374,7 @@ defmodule WebSockex.FrameTest do
 
       assert {:ok,
               <<1::1, 0::3, 8::4, 1::1, ^len::7, mask::bytes-size(4),
-                masked_payload::binary-size(len)>>} = Frame.encode_frame({:close, 1000, payload})
+                masked_payload::binary-size(^len)>>} = Frame.encode_frame({:close, 1000, payload})
 
       assert unmask(mask, masked_payload) == <<1000::16, payload::binary>>
     end


### PR DESCRIPTION
Elixir 1.20 is getting stricter regarding matching when a variable is used.
This changes remove a bunch of warnings of the form:
```
the variable "len" is accessed inside size(...) of a bitstring but it was defined
outside of the match. You must precede it with the pin operator
```

See https://github.com/elixir-lang/elixir/blob/v1.20/CHANGELOG.md#elixir-12 for the changelog